### PR TITLE
Elixir 1.6 compatability

### DIFF
--- a/lib/docset.ex
+++ b/lib/docset.ex
@@ -114,19 +114,19 @@ defmodule ExDash.Docset do
   end
 
   @info_plist_template """
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>CFBundleIdentifier</key> <string>{{CONFIG_PROJECT}}-{{CONFIG_VERSION}}</string>
-	<key>CFBundleName</key> <string>{{CONFIG_PROJECT}} {{CONFIG_VERSION}}</string>
-	<key>DocSetPlatformFamily</key> <string>{{CONFIG_PROJECT_ABBREV}}</string>
-	<key>isDashDocset</key> <true/>
-	<key>isJavaScriptEnabled</key> <true/>
-	<key>dashIndexFilePath</key> <string>index.html</string>
-	<key>DashDocSetFamily</key> <string>dashtoc</string>
-</dict>
-</plist>
+  <?xml version="1.0" encoding="UTF-8"?>
+  <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+  <plist version="1.0">
+  <dict>
+      <key>CFBundleIdentifier</key> <string>{{CONFIG_PROJECT}}-{{CONFIG_VERSION}}</string>
+      <key>CFBundleName</key> <string>{{CONFIG_PROJECT}} {{CONFIG_VERSION}}</string>
+      <key>DocSetPlatformFamily</key> <string>{{CONFIG_PROJECT_ABBREV}}</string>
+      <key>isDashDocset</key> <true/>
+      <key>isJavaScriptEnabled</key> <true/>
+      <key>dashIndexFilePath</key> <string>index.html</string>
+      <key>DashDocSetFamily</key> <string>dashtoc</string>
+  </dict>
+  </plist>
   """
 
   defp info_plist_content(%{project: name, version: version}) do

--- a/mix.exs
+++ b/mix.exs
@@ -33,9 +33,10 @@ defmodule ExDash.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:ex_doc, "~> 0.16"},
-      {:floki, "~> 0.14.0"},
-      {:cortex, "~> 0.1"}
+      {:ex_doc, "~> 0.18.3"},
+      {:floki, "~> 0.20.3"},
+      {:mochiweb_html, "~> 2.15"},
+      {:cortex, "~> 0.5.0"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ExDash.Mixfile do
 
   def project do
     [app: :ex_dash,
-     version: "0.1.6",
+     version: "0.1.7",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,12 @@
-%{"earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.16.0", "d598d2c654786a3de231202fcd1565a3df6c068c295cebc6d3d57589e8a97ea1", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "floki": {:hex, :floki, "0.14.0", "91a6be57349e10a63cf52d7890479a19012cef9185fa93c305d4fe42e6a50dee", [:mix], [{:mochiweb, "~> 2.15", [hex: :mochiweb, optional: false]}]},
+%{
+  "cortex": {:hex, :cortex, "0.5.0", "7b12ddcfa9fd61521dd3b841ef8a4758ccab895d6a5d4ed181a5a8ad4b4592a4", [:mix], [{:file_system, "~> 0.2", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "file_system": {:hex, :file_system, "0.2.6", "fd4dc3af89b9ab1dc8ccbcc214a0e60c41f34be251d9307920748a14bf41f1d3", [:mix], [], "hexpm"},
+  "floki": {:hex, :floki, "0.20.3", "dfb3a71eb99938e330b4156433d55c6d0b188d936c9683d115a8540bac56e019", [:mix], [{:html_entities, "~> 0.4.0", [hex: :html_entities, repo: "hexpm", optional: false]}, {:mochiweb, "~> 2.15", [hex: :mochiweb, repo: "hexpm", optional: false]}], "hexpm"},
+  "html_entities": {:hex, :html_entities, "0.4.0", "f2fee876858cf6aaa9db608820a3209e45a087c5177332799592142b50e89a6b", [:mix], [], "hexpm"},
   "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
   "mochiweb": {:hex, :mochiweb, "2.15.0", "e1daac474df07651e5d17cc1e642c4069c7850dc4508d3db7263a0651330aacc", [:rebar3], []},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []}}
+  "mochiweb_html": {:hex, :mochiweb_html, "2.15.0", "d7402e967d7f9f2912f8befa813c37be62d5eeeddbbcb6fe986c44e01460d497", [:rebar3], [], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
+}


### PR DESCRIPTION
Reduce compilation warnings with Elixir 1.6. 

The only source change was formatting a here document differently. Otherwise, update versions of libraries and bump version number.